### PR TITLE
Rename import package to reflect future org change to `cnabio`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,6 @@ jobs:
 
     - name: Build, Test, Lint
       run: |
+        export GOPATH=$HOME/go && export GOBIN=$(go env GOPATH)/bin && export PATH=$PATH:$GOPATH&& export PATH=$PATH:$GOBIN && mkdir -p $GOBIN
+
         GO111MODULE=on make bootstrap build test lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,14 +18,4 @@ jobs:
 
     - name: Build, Test, Lint
       run: |
-        export GOPATH=$HOME/go
-        export GOBIN=$(go env GOPATH)/bin
-        export PATH=$PATH:$GOPATH
-        export PATH=$PATH:$GOBIN
-        mkdir -p $GOPATH/pkg
-        mkdir -p $GOBIN
-        mkdir -p $GOPATH/src/github.com/$GITHUB_REPOSITORY
-        mv $(pwd)/* $GOPATH/src/github.com/$GITHUB_REPOSITORY
-        cd $GOPATH/src/github.com/$GITHUB_REPOSITORY
-
         GO111MODULE=on make bootstrap build test lint

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Engineerd
+Copyright (c) 2019 The CNAB Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PROJECT         := signy
-ORG             := engineerd
+ORG             := cnabio
 BINDIR          := $(CURDIR)/bin
 GOFLAGS         :=
 GOBUILDTAGS     := osusergo

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,6 @@ test:
 lint:
 	golangci-lint run --config ./golangci.yml
 
-HAS_DEP          := $(shell $(CHECK) dep)
 HAS_GOLANGCI     := $(shell $(CHECK) golangci-lint)
 HAS_GOIMPORTS    := $(shell $(CHECK) goimports)
 GOLANGCI_VERSION := v1.16.0

--- a/README.md
+++ b/README.md
@@ -1,11 +1,6 @@
 # Signy
 
-![](https://github.com/engineerd/signy/workflows/GitHub%20Actions/badge.svg) [![Build Status](https://dev.azure.com/engineerd-dev/signy/_apis/build/status/engineerd.signy?branchName=master)](https://dev.azure.com/engineerd-dev/signy/_build/latest?definitionId=5&branchName=master)
-
-Signy is a tool for exercising the TUF and in-toto specifications in order to sign various cloud-native artifacts. It uses the Notary client libraries, and communicates with a Notary server.
-It is an educational project with the purpose of implementing [the entire TUF workflow for signing content](https://github.com/theupdateframework/specification/blob/master/tuf-spec.md#5-detailed-workflows), and validate its correctness for [Cloud Native Application Bundles (CNAB)](https://github.com/deislabs/cnab-spec), and it is intended as a WIP reference implementation for its security specification.
-
-It implements signing and verifying for CNAB bundles in [the canonical formats (thin and thick bundles)](https://github.com/deislabs/cnab-spec/blob/master/104-bundle-formats.md).
+Signy is an experimental tool that implements the CNAB Security specification. It implements signing and verifying for CNAB bundles in [the canonical formats (thin and thick bundles)](https://github.com/deislabs/cnab-spec/blob/master/104-bundle-formats.md).
 
 ## Notes
 
@@ -19,9 +14,9 @@ It implements signing and verifying for CNAB bundles in [the canonical formats (
 
 ```bash
 $ cd $GOPATH/src/github.com
-$ mkdir engineerd && cd engineerd && git clone https://github.com/engineerd/signy && cd signy
-# This will build and install an updated version of the Signy binary in $GOPATH/bin whenever the source changes in $GOPATH/src/github.com/engineerd/signy.
-./scripts/live-reload.sh
+$ mkdir cnabio && cd cnabio && git clone https://github.com/cnabio/signy && cd signy
+$ make bootstrap build
+$ mv bin/signy $GOPATH/bin
 ```
 
 ## Using Signy

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -3,7 +3,7 @@ package main
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/engineerd/signy/pkg/tuf"
+	"github.com/cnabio/signy/pkg/tuf"
 )
 
 type listCmd struct {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/engineerd/signy/pkg/tuf"
+	"github.com/cnabio/signy/pkg/tuf"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )

--- a/cmd/sign.go
+++ b/cmd/sign.go
@@ -8,9 +8,9 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	"github.com/engineerd/signy/pkg/cnab"
-	"github.com/engineerd/signy/pkg/intoto"
-	"github.com/engineerd/signy/pkg/tuf"
+	"github.com/cnabio/signy/pkg/cnab"
+	"github.com/cnabio/signy/pkg/intoto"
+	"github.com/cnabio/signy/pkg/tuf"
 )
 
 type signCmd struct {

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -3,11 +3,11 @@ package main
 import (
 	"fmt"
 
-	"github.com/engineerd/signy/pkg/trust"
+	"github.com/cnabio/signy/pkg/trust"
 
 	"github.com/spf13/cobra"
 
-	"github.com/engineerd/signy/pkg/tuf"
+	"github.com/cnabio/signy/pkg/tuf"
 )
 
 type verifyCmd struct {
@@ -75,7 +75,7 @@ INFO[0001] The software product passed all verification.
 	cmd.Flags().StringVarP(&verify.localFile, "local", "", "", "Local file to validate the SHA256 against (mandatory for thick bundles)")
 
 	cmd.Flags().BoolVarP(&verify.intoto, "in-toto", "", false, "If passed, will try to fetch in-toto metadata from TUF and perform the verification")
-	cmd.Flags().StringVarP(&verify.verificationImage, "image", "", "docker.pkg.github.com/engineerd/in-toto-container/verification:v1", "container image to run the in-toto verification")
+	cmd.Flags().StringVarP(&verify.verificationImage, "image", "", "docker.pkg.github.com/cnabio/in-toto-container/verification:v1", "container image to run the in-toto verification")
 	cmd.Flags().BoolVarP(&verify.keepTempDir, "keep", "", false, "if passed, the temporary directory where the in-toto metadata is pulled is not deleted")
 	cmd.Flags().StringArrayVarP(&verify.targetFiles, "target", "", nil, "target files to copy in container for in-toto verifications")
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/engineerd/signy
+module github.com/cnabio/signy
 
 go 1.12
 

--- a/pkg/trust/sign.go
+++ b/pkg/trust/sign.go
@@ -4,9 +4,9 @@ import (
 	"encoding/hex"
 	"fmt"
 
-	"github.com/engineerd/signy/pkg/cnab"
-	"github.com/engineerd/signy/pkg/intoto"
-	"github.com/engineerd/signy/pkg/tuf"
+	"github.com/cnabio/signy/pkg/cnab"
+	"github.com/cnabio/signy/pkg/intoto"
+	"github.com/cnabio/signy/pkg/tuf"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/pkg/trust/validate.go
+++ b/pkg/trust/validate.go
@@ -8,9 +8,9 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/engineerd/signy/pkg/docker"
-	"github.com/engineerd/signy/pkg/intoto"
-	"github.com/engineerd/signy/pkg/tuf"
+	"github.com/cnabio/signy/pkg/docker"
+	"github.com/cnabio/signy/pkg/intoto"
+	"github.com/cnabio/signy/pkg/tuf"
 )
 
 // ValidateThinBundle runs the TUF and in-toto validations for a CNAB bundle in thin format (canonical JSON form)

--- a/pkg/tuf/sign.go
+++ b/pkg/tuf/sign.go
@@ -8,7 +8,7 @@ import (
 	"github.com/theupdateframework/notary/trustpinning"
 	"github.com/theupdateframework/notary/tuf/data"
 
-	"github.com/engineerd/signy/pkg/cnab"
+	"github.com/cnabio/signy/pkg/cnab"
 )
 
 // SignAndPublish signs an artifact, then publishes the metadata to a trust server

--- a/pkg/tuf/verify.go
+++ b/pkg/tuf/verify.go
@@ -10,7 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/theupdateframework/notary/client"
 
-	"github.com/engineerd/signy/pkg/cnab"
+	"github.com/cnabio/signy/pkg/cnab"
 )
 
 // VerifyCNABTrust ensures the trust metadata for a given GUN matches the metadata of the pushed bundle


### PR DESCRIPTION
This PR is preparing the moving of this repo into github.com/cnabio, the official GitHub organization for CNAB projects.

This PR:

- [x] updates the MIT license to "The CNAB Authors"
- [x] slightly updates the readme to reflect it is a reference implementation of the CNAB security spec
- [x] updates the Go package import paths from `github.com/engineerd/signy` to `github.com/cnabio/signy`.
