### PR TITLE
Add Radu and Trishank as codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,7 @@
+# This file is described here:  https://help.github.com/en/articles/about-code-owners
+
+# Global Owners: These members are Core Maintainers of signy
+CODEOWNERS      @radu-matei @trishankatdatadog
+LICENSE         @radu-matei @trishankatdatadog
+CONTRIBUTING.md @radu-matei @trishankatdatadog
+GOVERNANCE.md   @radu-matei @trishankatdatadog


### PR DESCRIPTION
closes #63 

This PR adds @radu-matei and @trishankatdatadog as CODEOWNERS for Signy.
