### PR TITLE
Fix linter settings and errors

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/cnabio/signy/pkg/tuf"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/cnabio/signy/pkg/tuf"
 )
 
 var (

--- a/golangci.yml
+++ b/golangci.yml
@@ -4,16 +4,16 @@ run:
 linters:
   disable-all: true
   enable:
-  - gofmt
-  - goimports
-  - golint
-  - gosimple
-  - ineffassign
-  - misspell
-  - unused
-  - deadcode
-  - govet
+    - gofmt
+    - goimports
+    - golint
+    - gosimple
+    - ineffassign
+    - misspell
+    - unused
+    - deadcode
+    - govet
 
 linters-settings:
   goimports:
-    local-prefixes: github.com/deislabs/duffle
+    local-prefixes: github.com/cnabio/signy

--- a/pkg/trust/sign.go
+++ b/pkg/trust/sign.go
@@ -4,10 +4,11 @@ import (
 	"encoding/hex"
 	"fmt"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/cnabio/signy/pkg/cnab"
 	"github.com/cnabio/signy/pkg/intoto"
 	"github.com/cnabio/signy/pkg/tuf"
-	log "github.com/sirupsen/logrus"
 )
 
 // SignAndPublish takes a CNAB bundle, pushes the signature and metadata to a trust server, then pushes the bundle


### PR DESCRIPTION
The `goimports` setting in the linter options were wrong, meaning `goimports` was not running properly.

This PR fixes that, as well as the linter errors.