### PR TITLE
Fix install of golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ ifndef HAS_GOLANGCI
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_VERSION)
 endif
 ifndef HAS_GOIMPORTS
-	go get -u golang.org/x/tools/cmd/goimports
+	go install golang.org/x/tools/cmd/goimports@latest
 endif
 
 .PHONY: e2e

--- a/Makefile
+++ b/Makefile
@@ -51,13 +51,13 @@ lint:
 
 HAS_GOLANGCI     := $(shell $(CHECK) golangci-lint)
 HAS_GOIMPORTS    := $(shell $(CHECK) goimports)
-GOLANGCI_VERSION := v1.23.6
+GOLANGCI_VERSION := v1.46.2
 
 
 .PHONY: bootstrap
 bootstrap:
 ifndef HAS_GOLANGCI
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(GOPATH)/bin $(GOLANGCI_VERSION)
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_VERSION)
 endif
 ifndef HAS_GOIMPORTS
 	go get -u golang.org/x/tools/cmd/goimports


### PR DESCRIPTION
Use go install to install the linter as what we have currently doesn't work anymore and causes the build to fail
